### PR TITLE
chore: remove ha

### DIFF
--- a/inventory/sample/inventory.ini
+++ b/inventory/sample/inventory.ini
@@ -7,12 +7,12 @@
 # We should set etcd_member_name for etcd cluster. The node that are not etcd members do not need to set the value,
 # or can set the empty string value.
 [kube_control_plane]
-kube2 ansible_host=192.168.1.12 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.12 etcd_member_name='kube2'
-kube4 ansible_host=192.168.1.14 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.14 etcd_member_name='kube4'
-kube0 ansible_host=192.168.1.10 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.10 etcd_member_name='kube0'
+kube0 ansible_host=192.168.1.10 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.10 etcd_member_name=''
 
 [etcd:children]
 kube_control_plane
 
 [kube_node]
 kube3 ansible_host=192.168.1.13 ansible_user=yusuf ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.13 etcd_member_name=''
+kube2 ansible_host=192.168.1.12 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.12 etcd_member_name=''
+kube4 ansible_host=192.168.1.14 ansible_user=ubuntu ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ip=192.168.1.14 etcd_member_name=''


### PR DESCRIPTION
Removed etcd_member_name values for kube0, kube2, and kube4.