### PR TITLE
fix: update gitea image tag to v1.25.5

### DIFF
--- a/charts/platform/templates/gitea.yaml
+++ b/charts/platform/templates/gitea.yaml
@@ -142,6 +142,7 @@ spec:
 
         image:
           registry: dockerhub.{{ .Values.domains.external }}/gitea
+          tag: 1.25.5
 
         imagePullSecrets:
           - name: cluster-docker-secrets


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/drgroot/kubespray/sessions/16b7959b-8285-42ae-8006-2a398a1b27f4