### PR TITLE
fix(platform): update htpasswd templates for ESO 2.x

### DIFF
--- a/charts/platform/templates/npm.yaml
+++ b/charts/platform/templates/npm.yaml
@@ -13,8 +13,8 @@ spec:
       type: Opaque
       data:
         htpasswd: |
-          {{ `{{ htpasswd .PRIVATE_USERNAME .PRIVATE_PASSWORD }}` }}
-          {{ `{{ htpasswd .npm_read_user .npm_read_password }}` }}
+          {{ `{{ htpasswd .PRIVATE_USERNAME .PRIVATE_PASSWORD "bcrypt" }}` }}
+          {{ `{{ htpasswd .npm_read_user .npm_read_password "bcrypt" }}` }}
   data:
     - remoteRef:
         key: DOCKER_PRIVATE

--- a/charts/platform/templates/registry.yaml
+++ b/charts/platform/templates/registry.yaml
@@ -20,7 +20,7 @@ spec:
     template:
       type: Opaque
       data:
-        htpasswd: "{{ `{{ htpasswd .PRIVATE_USERNAME .PRIVATE_PASSWORD }}` }}"
+        htpasswd: '{{ `{{ htpasswd .PRIVATE_USERNAME .PRIVATE_PASSWORD "bcrypt" }}` }}'
   data:
     - remoteRef:
         key: DOCKER_PRIVATE


### PR DESCRIPTION
Updates External Secrets htpasswd templates for ESO 2.x, which requires the hash algorithm argument.