### PR TITLE
chore: increase runner and pypi cpu

### DIFF
--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -29,7 +29,7 @@ pypi:
     tag: latest
 
   resources:
-    cpu: 100m
+    cpu: "1"
     memory: 64Mi
 
 npm:
@@ -348,7 +348,7 @@ gitea:
     resources:
       requests:
         memory: "2Gi"
-        cpu: "500m"
+        cpu: "1"
       limits:
         memory: "4Gi"
-        cpu: "1"
+        cpu: "2"

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -29,7 +29,7 @@ pypi:
     tag: latest
 
   resources:
-    cpu: "1"
+    cpu: 250m
     memory: 64Mi
 
 npm:


### PR DESCRIPTION
## Summary
- increase the Gitea actions runner CPU request from 500m to 1 and limit from 1 to 2
- increase the internal pypi server CPU from 100m to 1

## Why
These changes give the runners more CPU headroom for package installs and builds, and remove the most obvious CPU bottleneck on the pypi mirror.