### PR TITLE
bootstrap: source servc Vault credentials externally

### DIFF
--- a/charts/bootstrap/templates/externalsecrets.yaml
+++ b/charts/bootstrap/templates/externalsecrets.yaml
@@ -73,3 +73,28 @@ spec:
             key: {{ .Values.vault.key }}
             namespace: {{ .Release.Namespace }}
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.vault.servc.secretName }}
+  namespace: {{ .Values.vault.servc.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: external-infra
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.vault.servc.secretName }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.vault.servc.remoteKey }}
+        property: {{ .Values.vault.servc.usernameProperty }}
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.vault.servc.remoteKey }}
+        property: {{ .Values.vault.servc.passwordProperty }}

--- a/charts/bootstrap/values.yaml
+++ b/charts/bootstrap/values.yaml
@@ -4,6 +4,12 @@ vault:
   username: kubernetesadmin
   secretName: vault-password
   key: password
+  servc:
+    namespace: argocd
+    secretName: vault-password
+    remoteKey: VAULT
+    usernameProperty: servc-username
+    passwordProperty: servc-password
   image:
     repository: hashicorp/vault
     tag: "1.19.5"


### PR DESCRIPTION
Adds an ExternalSecret that materializes `argocd/vault-password` from the `external-infra` ClusterSecretStore. It reads Vault key `VAULT` properties `servc-username` and `servc-password`, removing the need for that credential to be managed as a plain Kubernetes Secret.